### PR TITLE
Fix local path resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ exports.resolve = function resolveKibanaPath(source, file, config) {
   const kibanaPath = getKibanaPath(config, file, rootPath);
 
   // check relative paths
-  const relativeImport = source.match(new RegExp('^\.\.?/(.*)'));
+  const relativeImport = source.match(new RegExp('^\\.\\.?/(.*)'));
   if (relativeImport !== null) {
     return resolveLocalRelativeImport(source, file);
   }

--- a/index.js
+++ b/index.js
@@ -11,13 +11,13 @@ const defaults = {
  * Resolves the path to Kibana, either from default setting or config
  */
 function getKibanaPath(config, file, rootPath) {
-  if (config != null && config.kibanaPath) {
-    return path.resolve(config.kibanaPath);
-  }
+  const inConfig = config != null && config.kibanaPath;
 
-  const kibanaPath = path.resolve(rootPath, defaults.kibanaPath);
+  const kibanaPath = (inConfig)
+    ? path.resolve(config.kibanaPath)
+    : path.resolve(rootPath, defaults.kibanaPath);
+
   debug(`resolved kibana path: ${kibanaPath}`);
-
   return kibanaPath;
 }
 

--- a/index.js
+++ b/index.js
@@ -103,8 +103,9 @@ function resolvePluginsAliasImport(pluginsImport, kibanaPath, rootPath) {
  * @param {String} rootPath: root path of the project code
  */
 function resolveLocalRelativeImport(fileImport, file) {
-  const sourceBase = path.basename(fileImport, '.js');
-  const localPath = path.dirname(path.resolve(path.dirname(file), sourceBase));
+  const sourceBase = path.basename(fileImport);
+  const localPath = path.dirname(path.resolve(path.dirname(file), fileImport));
+  debug(`resolving relative path: ${localPath}`);
   const matches = getFileMatches(sourceBase, localPath);
   return getMatch(matches, localPath);
 }


### PR DESCRIPTION
Local path resolution like (`../thing` and `./stuff`) was failing when the local path was relying on the webpack aliases.

This PR fixes the issue. It also renames some methods and adds a little more debugging output.