### PR TITLE
Check in public for matching webpackShims

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function getMatch(matches, checkPath) {
  */
 function resolvePluginsAliasImport(pluginsImport, kibanaPath, rootPath) {
   const { name: packageName } = require(path.resolve(rootPath, 'package.json'));
-  const [ pluginName, ...importPaths ] = pluginsImport[1].split('/');
+  const [ pluginName, ...importPaths ] = pluginsImport[1].split(path.sep);
   debug(`resolvePluginsAliasImport: package ${packageName}, plugin ${pluginName}, import ${importPaths.join('/')}`);
 
   if (packageName !== 'kibana' && packageName === pluginName) {
@@ -120,7 +120,7 @@ function resolveLocalRelativeImport(fileImport, file) {
  */
 function resolveWebpackShim(source, kibanaPath, rootPath) {
   debug(`resolveWebpackShim: resolving ${source}`);
-  const sourceParts = source.split('/');
+  const sourceParts = source.split(path.sep);
   const baseSource = sourceParts.pop();
 
   const pluginShimPaths = [

--- a/index.js
+++ b/index.js
@@ -119,22 +119,25 @@ function resolveLocalRelativeImport(fileImport, file) {
  * @param {String} rootPath: root path of the project code
  */
 function resolveWebpackShim(source, kibanaPath, rootPath) {
-  const pluginShimPath = path.join(rootPath, 'webpackShims');
-  const pluginMatches = getFileMatches(source, pluginShimPath);
-  const pluginFileMatches = getMatch(pluginMatches, pluginShimPath);
-  debug(`resolveWebpackShim: checking for ${source}`);
-  if (pluginFileMatches.found) {
-    debug(`resolved webpackShim import in plugin: ${source}`);
-    return pluginFileMatches;
-  }
+  debug(`resolveWebpackShim: resolving ${source}`);
+  const sourceParts = source.split('/');
+  const baseSource = sourceParts.pop();
 
-  const kibanaShimPath = path.join(kibanaPath, 'webpackShims');
-  const kibanaMatches = getFileMatches(source, kibanaShimPath);
-  const kibanaFileMatches = getMatch(kibanaMatches, kibanaShimPath);
-  if (kibanaFileMatches.found) {
-    debug(`resolved webpackShim import in Kibana: ${source}`);
-  }
-  return kibanaFileMatches;
+  const pluginShimPaths = [
+    path.join(rootPath, 'webpackShims', ...sourceParts),
+    path.join(rootPath, 'public', 'webpackShims', ...sourceParts),
+    path.join(kibanaPath, 'webpackShims', ...sourceParts),
+  ];
+
+  const pluginFileMatches = pluginShimPaths.reduce((acc, pluginShimPath) => {
+    if (acc.found) return acc; // stop checking once there's a match
+
+    const pluginMatches = getFileMatches(baseSource, pluginShimPath);
+    return getMatch(pluginMatches, pluginShimPath);
+  }, {});
+
+  if (pluginFileMatches.found) debug(`resolved webpackShim import in plugin: ${source}`);
+  return pluginFileMatches;
 }
 
 /*


### PR DESCRIPTION
Closes #13

Check for a matching `webpackShims` path, starting at the plugin root, walk all the way to the requesting file, then check Kibana's root. Stops as soon as it finds a match, so in most cases, only the first condition is needed. 