### PR TITLE
Include root as plugin

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,5 +1,0 @@
-module.exports = {
-  kibanaPath: '../kibana',
-  pluginDirs: [],
-  pluginPaths: [],
-};

--- a/lib/get_kibana_path.js
+++ b/lib/get_kibana_path.js
@@ -1,20 +1,17 @@
 const { resolve } = require('path');
 const debug = require('./debug');
-const defaults = require('./defaults');
 
-let kibanaPath;
+const DEFAULT_PLUGIN_PATH = '../kibana';
 
 /*
  * Resolves the path to Kibana, either from default setting or config
  */
 module.exports = function getKibanaPath(config, projectRoot) {
-  if (kibanaPath) return kibanaPath;
-
   const inConfig = config != null && config.kibanaPath;
 
-  kibanaPath = (inConfig)
+  const kibanaPath = (inConfig)
     ? resolve(config.kibanaPath)
-    : resolve(projectRoot, defaults.kibanaPath);
+    : resolve(projectRoot, DEFAULT_PLUGIN_PATH);
 
   debug(`Resolved Kibana path: ${kibanaPath}`);
   return kibanaPath;

--- a/lib/get_plugins.js
+++ b/lib/get_plugins.js
@@ -1,18 +1,16 @@
 const { dirname, resolve } = require('path');
 const glob = require('glob-all');
 
-const defaults = require('./defaults');
-
 module.exports = function getPlugins(config, kibanaPath, projectRoot) {
   const pluginDirs = [
-    ...(config.pluginDirs || defaults.pluginDirs),
+    ...(config.pluginDirs || []),
     resolve(kibanaPath, 'plugins'),
     resolve(kibanaPath, 'src', 'core_plugins'),
   ];
 
   const globPatterns = [
     ...pluginDirs.map(dir => `${dir}/*/package.json`),
-    ...(config.pluginPaths || defaults.pluginPaths).map(path => `${path}/package.json`),
+    ...(config.pluginPaths || []).map(path => `${path}/package.json`),
   ];
   const globOptions = { cwd: projectRoot };
 

--- a/lib/get_plugins.js
+++ b/lib/get_plugins.js
@@ -12,6 +12,10 @@ module.exports = function getPlugins(config, kibanaPath, projectRoot) {
 
   const pluginPaths = [
     ...(config.pluginPaths || []).map(resolveToRoot),
+    
+    // when the rootPackageName is specified we assume that the root of the project
+    // is not a plugin, so don't include it automatically
+    ...(config.rootPackageName ? [] : [projectRoot])
   ];
 
   const globPatterns = [

--- a/lib/get_plugins.js
+++ b/lib/get_plugins.js
@@ -2,19 +2,24 @@ const { dirname, resolve } = require('path');
 const glob = require('glob-all');
 
 module.exports = function getPlugins(config, kibanaPath, projectRoot) {
+  const resolveToRoot = path => resolve(projectRoot, path);
+
   const pluginDirs = [
-    ...(config.pluginDirs || []),
+    ...(config.pluginDirs || []).map(resolveToRoot),
     resolve(kibanaPath, 'plugins'),
-    resolve(kibanaPath, 'src', 'core_plugins'),
+    resolve(kibanaPath, 'src/core_plugins'),
+  ];
+
+  const pluginPaths = [
+    ...(config.pluginPaths || []).map(resolveToRoot),
   ];
 
   const globPatterns = [
-    ...pluginDirs.map(dir => `${dir}/*/package.json`),
-    ...(config.pluginPaths || []).map(path => `${path}/package.json`),
+    ...pluginDirs.map(dir => resolve(dir, '*/package.json')),
+    ...pluginPaths.map(path => resolve(path, 'package.json')),
   ];
-  const globOptions = { cwd: projectRoot };
 
-  return glob.sync(globPatterns, globOptions).map(pkgJsonPath => {
+  return glob.sync(globPatterns).map(pkgJsonPath => {
     const path = dirname(pkgJsonPath);
     const pkg = require(pkgJsonPath);
     return {


### PR DESCRIPTION
- remove default module, it is about to become insufficient 
- resolve plugin dirs relative to the project root
- treat project as plugin unless `rootPackageName` specified