### PR TITLE
include the node resolver for built-ins not supported by webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const webpackResolver = require('eslint-import-resolver-webpack');
+const nodeResolver = require('eslint-import-resolver-node');
 const getProjectRoot = require('./lib/get_project_root');
 const getWebpackConfig = require('./lib/get_webpack_config');
 
@@ -9,9 +10,15 @@ let webpackConfig;
 exports.resolve = function resolveKibanaPath(source, file, config) {
   const settings = config || {};
 
+  // try to resolve with the node resolver first
+  const resolvedWithNode = nodeResolver.resolve(source, file, config);
+  if (resolvedWithNode && resolvedWithNode.found) {
+    return resolvedWithNode;
+  }
+
+  // fall back to the webpack resolver
   projectRoot = projectRoot || getProjectRoot(file, settings);
   webpackConfig = webpackConfig || getWebpackConfig(source, projectRoot, settings);
-
   return webpackResolver.resolve(source, file, {
     config: webpackConfig
   });

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@elastic/webpack-directory-name-as-main": "^2.0.3",
     "debug": "^2.6.6",
+    "eslint-import-resolver-node": "^0.3.0",
     "eslint-import-resolver-webpack": "^0.8.1",
     "glob-all": "^3.1.0",
     "webpack": "github:elastic/webpack#fix/query-params-for-aliased-loaders"


### PR DESCRIPTION
The webpack resolver supports all of the same node_module and relative path imports that the node resolver does, but there are certain modules like `v8` that are not supported by webpack and therefore do not resolve with the webpack resolver. This embeds the node-resolver too so that it is checked first then falls back to the webpack resolver.