### PR TITLE
Allow projectRoot override in config

### DIFF
--- a/lib/get_project_root.js
+++ b/lib/get_project_root.js
@@ -2,6 +2,15 @@ const { dirname, resolve, parse } = require('path');
 const { accessSync, readFileSync } = require('fs');
 const debug = require('./debug');
 
+function getConfig(config) {
+  const defaults = {
+    projectRoot: true,
+  };
+
+  if (!config || !config['@elastic/eslint-import-resolver-kibana']) return defaults;
+  return Object.assign(defaults, config['@elastic/eslint-import-resolver-kibana']);
+}
+
 function getRootPackageDir(dirRoot, dir, rootPackageName) {
   if (dirRoot === dir) return null;
   const pkgFile = resolve(dir, 'package.json');
@@ -13,8 +22,10 @@ function getRootPackageDir(dirRoot, dir, rootPackageName) {
     if (!rootPackageName) return dir;
 
     // if rootPackageName is provided, check for match
-    const { name } = JSON.parse(readFileSync(pkgFile));
-    if (name === rootPackageName) return dir;
+    const { name, config } = JSON.parse(readFileSync(pkgFile));
+    const { projectRoot } = getConfig(config);
+
+    if (projectRoot && name === rootPackageName) return dir;
 
     // recurse until a matching package.json is found
     return getRootPackageDir(dirRoot, dirname(dir), rootPackageName);


### PR DESCRIPTION
Reads optional config proprty from package.json and will skip resolution if projectRoot is `false`.

Useful for when plugins share a name with the package root's package.json file.

**Example usage**

```js
// plugins/package.json
{
  "name": "my-plugin",
  "config": {
    "@elastic/eslint-import-resolver-kibana": {
      "projectRoot": false
    }
  }
}
```

```js
// package.json
{
  "name": "my-plugin",
  "version": "kibana"
}
```

Here, setting `rootPackageName: 'my-plugin'` in the eslintrc file will skip the package.json in `plugins` and use the one in the project root, as expected.